### PR TITLE
chore: Revise Category Query Param

### DIFF
--- a/functions/api/petitions.ts
+++ b/functions/api/petitions.ts
@@ -122,11 +122,10 @@ export const onRequest = async (context: EventContext<Env>): Promise<Response> =
       const offset = parseInt(url.searchParams.get('offset') || '0')
       const userId = url.searchParams.get('userId')
 
-      // Parse categories parameter (comma-separated category IDs)
-      const categoriesParam = url.searchParams.get('categories')
-      const categoryIds = categoriesParam
-        ? categoriesParam
-            .split(',')
+      // Parse category[] array parameters
+      const categoryParams = url.searchParams.getAll('category[]')
+      const categoryIds = categoryParams.length > 0
+        ? categoryParams
             .map(id => parseInt(id.trim()))
             .filter(id => !isNaN(id))
         : undefined

--- a/functions/api/petitions.ts
+++ b/functions/api/petitions.ts
@@ -1,13 +1,13 @@
 import type { CreatePetitionInput } from '../../src/db/schemas/types'
 import type { Env, EventContext } from '../_shared/types'
 import {
-  handleCORS,
-  createSuccessResponse,
-  createCachedResponse,
   createCachedErrorResponse,
-  getDbService,
+  createCachedResponse,
+  createSuccessResponse,
   generateCacheKey,
+  getDbService,
   getOrSetCache,
+  handleCORS,
   invalidateCachePattern,
   type AuthenticatedUser,
 } from '../_shared/utils'
@@ -124,11 +124,10 @@ export const onRequest = async (context: EventContext<Env>): Promise<Response> =
 
       // Parse category[] array parameters
       const categoryParams = url.searchParams.getAll('category[]')
-      const categoryIds = categoryParams.length > 0
-        ? categoryParams
-            .map(id => parseInt(id.trim()))
-            .filter(id => !isNaN(id))
-        : undefined
+      const categoryIds =
+        categoryParams.length > 0
+          ? categoryParams.map(id => parseInt(id.trim())).filter(id => !isNaN(id))
+          : undefined
 
       // Generate cache key for this request
       const cacheKey = generateCacheKey(context.request, 'petitions')

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -163,7 +163,9 @@ export const petitionApi = {
     if (params.offset) searchParams.set('offset', params.offset.toString())
     if (params.type) searchParams.set('type', params.type)
     if (params.categories && params.categories.length > 0) {
-      searchParams.set('categories', params.categories.join(','))
+      params.categories.forEach(category => {
+        searchParams.append('category[]', category)
+      })
     }
 
     return apiRequest<PetitionWithDetails[]>(`/api/petitions?${searchParams}`)

--- a/tests/e2e/petitions.spec.ts
+++ b/tests/e2e/petitions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
 test.describe('Petition Browsing', () => {
   test('should display petition list on homepage', async ({ page }) => {
@@ -78,5 +78,32 @@ test.describe('Petition Browsing', () => {
       // At minimum, the page shouldn't crash
       await expect(page).not.toHaveURL(/error/)
     }
+  })
+
+  test('should filter petitions by category', async ({ page }) => {
+    await page.goto('/petitions')
+
+    const economyPetition = page.getByRole('heading', { name: 'Modernize Philippine Agriculture' })
+    const educationPetition = page.getByRole('heading', {
+      name: 'Free Wi-Fi in All Public Schools Nationwide',
+    })
+    const categorySuggestions = page.getByRole('listbox', { name: 'Suggestions' })
+
+    // Ensure the economy petition is initially visible
+    await expect(economyPetition).toBeVisible()
+
+    await page.getByRole('button', { name: 'Categories' }).click()
+    await expect(categorySuggestions).toBeVisible()
+
+    // After selecting Education category, economy petition should be hidden
+    await categorySuggestions.getByRole('option', { name: 'Education' }).click()
+    await expect(economyPetition).not.toBeVisible()
+    await expect(educationPetition).toBeVisible()
+
+    // Check for multiple category selection
+    // After selecting Economy category, both petitions should be visible
+    await categorySuggestions.getByRole('option', { name: 'Economy' }).click()
+    await expect(economyPetition).toBeVisible()
+    await expect(educationPetition).toBeVisible()
   })
 })


### PR DESCRIPTION
## Overview

This is a follow-up PR for a comment in PR #16.

## Changes

- Changed `categories=1,2,3` query param to `category[]=1&category[]=2`
- Added a test for category filtering

## Testing

Tested locally.


_Made sure that the Category filter is still working as expected._


https://github.com/user-attachments/assets/026132b1-b5da-4d0d-b791-e96916ce6dea

