### PR TITLE
fix(ui): fix for bug #25 useEffect dependencies and handleLoadMore state update

### DIFF
--- a/src/components/AllPetitions.tsx
+++ b/src/components/AllPetitions.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input'
 import { DEFAULT_CATEGORIES } from '@/constants/categories'
 import { categoryApi, petitionApi } from '@/services/api'
 import type { PetitionWithDetails } from '@/types/api'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { Category } from '../types/api'
 import FilterPopover from './shared/FilterPopover'
@@ -51,16 +51,12 @@ export default function AllPetitions() {
     [categories]
   )
 
-  const fetchPetitions = useCallback(
-    async (reset = false) => {
+  useEffect(() => {
+    const load = async () => {
       try {
-        if (reset) {
-          setLoading(true)
-          setPage(1)
-        }
+        setLoading(true)
 
-        const currentPage = reset ? 1 : page
-        const offset = (currentPage - 1) * PETITIONS_PER_PAGE
+        const offset = (page - 1) * PETITIONS_PER_PAGE
 
         const data = await petitionApi.getAll({
           limit: PETITIONS_PER_PAGE,
@@ -69,35 +65,26 @@ export default function AllPetitions() {
           categories: selectedCategories.length > 0 ? selectedCategories : undefined,
         })
 
-        if (reset) {
-          setPetitions(data)
-        } else {
-          setPetitions(prev => [...prev, ...data])
-        }
-
+        // reset if page === 1
+        setPetitions(prev => (page === 1 ? data : [...prev, ...data]))
         setHasMore(data.length === PETITIONS_PER_PAGE)
-      } catch (err) {
-        console.error('Failed to fetch petitions:', err)
+      } catch (error) {
+        console.error('Failed to load petitions:', error)
         setError('Failed to load petitions. Please try again later.')
       } finally {
         setLoading(false)
       }
-    },
-    [filter, page, selectedCategories]
-  )
-
-  useEffect(() => {
-    fetchPetitions(true) // Reset when filters change
-  }, [filter, selectedCategories])
-
-  useEffect(() => {
-    if (page !== 1) {
-      fetchPetitions(false)
     }
-  }, [page])
+
+    load()
+  }, [page, filter, selectedCategories])
 
   const handleLoadMore = () => {
     setPage(prev => prev + 1)
+  }
+
+  const handleTryAgain = () => {
+    setPage(1)
   }
 
   const handleCategorySelect = (value: string) => {
@@ -227,7 +214,7 @@ export default function AllPetitions() {
           ) : error ? (
             <div className="text-center py-12">
               <p className="text-lg text-red-600">{error}</p>
-              <Button onClick={() => fetchPetitions(true)} className="mt-4">
+              <Button onClick={handleTryAgain} className="mt-4">
                 Try Again
               </Button>
             </div>

--- a/src/components/AllPetitions.tsx
+++ b/src/components/AllPetitions.tsx
@@ -88,11 +88,16 @@ export default function AllPetitions() {
 
   useEffect(() => {
     fetchPetitions(true) // Reset when filters change
-  }, [filter, selectedCategories, fetchPetitions])
+  }, [filter, selectedCategories])
+
+  useEffect(() => {
+    if (page !== 1) {
+      fetchPetitions(false)
+    }
+  }, [page])
 
   const handleLoadMore = () => {
     setPage(prev => prev + 1)
-    fetchPetitions(false)
   }
 
   const handleCategorySelect = (value: string) => {


### PR DESCRIPTION
**Summary**

- removed calling `fetchPetition()` inside `handleLoadMore` function 
- removed `fetchPetition()` and added `useEffect` on page, categories, and filter changes.
- added `handleTryAgain` function for the Try Again btn

**Testing**
Note: For testing in `dev` below, I changed `PETITIONS_PER_PAGE` to 3 since dev db only has 5 petitions in total.

Before:
https://www.loom.com/share/4373fa3e4acc4ce28f37292a3aaae0fa

After:
https://www.loom.com/share/87822db864ce45c5abc40e289e15e752
